### PR TITLE
Update deb packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea/
 .DS_Store
+deb/fio/usr/local/bin/fiotop
+deb/fio/usr/local/bin/fioreq

--- a/deb/fio/DEBIAN/control
+++ b/deb/fio/DEBIAN/control
@@ -1,9 +1,9 @@
 Package: fioprotocol
 Version: 1.0.x-xxxxxxxxxxxx
-Depends: libssl1.1 (>= 1.1.1), curl (>= 7.0.0)
+Depends: libssl1.1 (>= 1.1.1), curl (>= 7.0.0), libcurl4-gnutls-dev (>= 7.58.0)
 Priority: optional
 Architecture: amd64
 Maintainer: Dapix <security@dapix.io>
-Description: FIO testnet setup
- Basic set of daemons and configuration for joining the FIO testnet.
+Description: FIO protocol daemons and utilities
+ Basic set of daemons and configuration for joining the FIO network.
 

--- a/deb/fio/etc/fio/nodeos/mainnet-config.ini
+++ b/deb/fio/etc/fio/nodeos/mainnet-config.ini
@@ -117,7 +117,6 @@ p2p-peer-address = p2p.fio.zenblocks.io:9866 # ZenBlocks (bp@zenblocks)
 p2p-peer-address = fio.blockpane.com:9876 # Blockpane (not a producer)
 p2p-peer-address = fio.greymass.com:49876 # Greymass (bp@greymass)
 p2p-peer-address = fio.eosusa.news:9886 # EOSUSA (bp@eosusa)
-p2p-peer-address = p2p.fioprotocol.io:3856  # Foundation for Interwallet Operability
 p2p-peer-address = p2p.fio.eosargentina.io:1984 # EOS Argentina (fio@eosargentina)
 p2p-peer-address = fio.cryptolions.io:7987 # CryptoLions (bp@cryptolions)
 p2p-peer-address = peer.fio-mainnet.eosblocksmith.io:8090 # Blocksmith ( blocksmith@blocksmith )

--- a/deb/fio/etc/fio/nodeos/mainnet-config.ini
+++ b/deb/fio/etc/fio/nodeos/mainnet-config.ini
@@ -103,19 +103,33 @@ plugin = eosio::db_size_api_plugin
 #history-per-account = 10000
 
 p2p-peer-address = 34.232.117.155:9876
-p2p-peer-address = fio.eu.eosamsterdam.net:9956
-p2p-peer-address = fio.eosdac.io:6876
-p2p-peer-address = fiopeer1.nodeone.io:6981
-p2p-peer-address = peer.fio.alohaeos.com:9876
-p2p-peer-address = peer1-fio.eosphere.io:9876
-p2p-peer-address = fiomainnet.everstake.one:7770
-p2p-peer-address = fio.eosrio.io:8122
-p2p-peer-address = fio.acherontrading.com:9876
-p2p-peer-address = fio.eos.barcelona:3876
-p2p-peer-address = p2p.fio.eosdetroit.io:1337
-p2p-peer-address = p2p.fio.zenblocks.io:9866
-p2p-peer-address = fio.blockpane.com:9876
-p2p-peer-address = p2p.fioprotocol.io:3856
+p2p-peer-address = fio.eu.eosamsterdam.net:9956 # (bp@eosamsterdam)
+p2p-peer-address = fio.eosdac.io:6876 # eosDAC (bp@thedac)
+p2p-peer-address = fiopeer1.nodeone.io:6981 # NodeOne (fionodeonebp@nodeone)
+p2p-peer-address = peer.fio.alohaeos.com:9876 # Aloha EOS (bp@alohaeos)
+p2p-peer-address = peer1-fio.eosphere.io:9876 # EOSphere (bp@eosphere)
+p2p-peer-address = fiomainnet.everstake.one:7770 # Everstake (bp@everstake)
+p2p-peer-address = fio.eosrio.io:8122 # EOS Rio (br@eosrio)
+p2p-peer-address = fio.acherontrading.com:9876 # Acheron Trading (bp@acherontrading)
+p2p-peer-address = fiop2p.eos.barcelona:3876 # eosBarcelona (bp@eosbarcelona)
+p2p-peer-address = p2p.fio.eosdetroit.io:1337 # EOS Detroit (eosio@detroit)
+p2p-peer-address = p2p.fio.zenblocks.io:9866 # ZenBlocks (bp@zenblocks)
+p2p-peer-address = fio.blockpane.com:9876 # Blockpane (not a producer)
+p2p-peer-address = fio.greymass.com:49876 # Greymass (bp@greymass)
+p2p-peer-address = fio.eosusa.news:9886 # EOSUSA (bp@eosusa)
+p2p-peer-address = p2p.fioprotocol.io:3856  # Foundation for Interwallet Operability
+p2p-peer-address = p2p.fio.eosargentina.io:1984 # EOS Argentina (fio@eosargentina)
+p2p-peer-address = fio.cryptolions.io:7987 # CryptoLions (bp@cryptolions)
+p2p-peer-address = peer.fio-mainnet.eosblocksmith.io:8090 # Blocksmith ( blocksmith@blocksmith )
+p2p-peer-address = p2p.fio.services:9876 # Gandalf ( gandalf@grey )
+p2p-peer-address = peer.fio.currencyhub.io:9876 # Currency Hub (bp@thecurrencyhub)
+p2p-peer-address = fio.mycryptoapi.com:9876 # MyCrypto (bp@mycrypto)
+p2p-peer-address = fiop2p.eoscannon.io:6789 # EOSCannon (bp@eoscannon)
+p2p-peer-address = fio.eosdublin.io:9976 # eosDublin (bp@eosdublin)
+p2p-peer-address = fio.guarda.co:9976 #Guarda Wallet (bp@guardaw)
+p2p-peer-address = fio.eossweden.org:9376 # sw/eden (bp@fiosweden)
+p2p-peer-address = fio.maltablock.org:9876 # Maltablock (bp@maltablock)
+
 
 
 

--- a/deb/fio/usr/local/bin/fio-nodeos-run
+++ b/deb/fio/usr/local/bin/fio-nodeos-run
@@ -2,5 +2,5 @@
 
 /bin/mkdir -p /var/lib/fio/data
 
-exec /usr/local/bin/fio-nodeos --data-dir /var/lib/fio/data --config-dir /etc/fio/nodeos
+exec /usr/local/bin/fio-nodeos --data-dir /var/lib/fio/data --config-dir /etc/fio/nodeos --genesis-json /etc/fio/nodeos/genesis.json
 

--- a/deb/fio/usr/local/bin/fio-nodeos-run
+++ b/deb/fio/usr/local/bin/fio-nodeos-run
@@ -1,17 +1,6 @@
 #!/bin/bash
 
 /bin/mkdir -p /var/lib/fio/data
-OPTIONS=""
-if [ ! -f /var/lib/fio/.genesis_done ]; then
-    OPTIONS="--genesis-json /etc/fio/nodeos/genesis.json"
-    touch /var/lib/fio/.genesis_done
-fi
-MYIP=$(/usr/bin/curl -m2 -s http://169.254.169.254/latest/meta-data/public-ipv4 2>/dev/null |head -1 |grep -v xml)
-if [ ! -z "$MYIP" ] ; then
-    OPTIONS="--p2p-server-address $MYIP:3856 $OPTIONS"
-fi
 
-trap 'pkill -u fio -n nodeos' SIGINT SIGTERM
-
-exec /usr/local/bin/fio-nodeos --data-dir /var/lib/fio/data --config-dir /etc/fio/nodeos $OPTIONS
+exec /usr/local/bin/fio-nodeos --data-dir /var/lib/fio/data --config-dir /etc/fio/nodeos
 

--- a/deb/fio/usr/local/share/fio/README
+++ b/deb/fio/usr/local/share/fio/README
@@ -8,8 +8,6 @@ Notes:
 * Systemd units are installed, but none are enabled at install.
   The availble systemd units are: fio-keosd.service, and fio-nodeos.service
 * Data is stored in /var/lib/fio
-* If initial syncronization fails, or otherwise need to start syncing from genesis, remove the file /var/lib/fio/.genesis_done
-  so that when the service starts it will use the genesis.json file
 * Both nodeos and keosd run under restrictive apparmor profiles, and with additional seccomp rules (via systemd).
 * Log rotation is configured.
 


### PR DESCRIPTION
Addresses #2 
- remove .genesis_done file
- no longer attempts to get public IP from aws metadata v1
- remove trap in script for running podman containers

Addresses #3 
- add missing dependency
- update control file descriptions

Extra
- update with latest known producer mainnet p2p endpoints 
- package will include fiotop and fioreq from fio-go repo, adding these to .gitignore